### PR TITLE
added &> /dev/null to azdo dockerfile

### DIFF
--- a/Dockerfile.azure-pipelines
+++ b/Dockerfile.azure-pipelines
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommend
     iputils-ping \
     jq \
     lsb-release \
-    software-properties-common
+    software-properties-common &> /dev/null
 
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
I faced an issue when calling this script in Terraform using the local-exec provisioner where some of the output of the 4th step could not be parsed due to a missing encoding setting in Terraform. 

The only thing i changed is redirecting the output of this step to /dev/null. As such, the output of the 4th step when calling this in a script does not go trough terraform (or anything really) so no parsing issues can occur.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

* Test the code
Run the following command 
az acr build --registry "{registery_name}" --image "azure-pipelines-agent:1.0" --file "Dockerfile.azure-pipelines" "https://github.com/Azure-Samples/container-apps-ci-cd-runner-tutorial.git"


## What to Check
No output from the 4the step

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Below you can find the way I call the dockerfile in Terraform. It invokes the command but the output is going trough Terraform which causes the following error.
UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in position 3169: character maps to <undefined>

As you can see, there is a parsing error due to the nature of the output from the dockerfile. Thats why supressing the output of the buildstep is a quick fix for this issue.

Another way to fix this would be to add the encoding="utf-8" in the function that is being used to invoke this command. But that would be on a change on the Terraform side.

Feel free to provide feedback or discuss this further.

resource "null_resource" "create_image" {
  for_each = { for k, v in var.container_registries : k => v }
  provisioner "local-exec" {
    command =  "az acr build --no-format --registry  ${module.container_registry[each.key].data.name} --image azure-pipelines-agent:1.0 --file Dockerfile.azure-pipelines https://github.com/Azure-Samples/container-apps-ci-cd-runner-tutorial.git"
  }
}